### PR TITLE
Correctly handle last mpd

### DIFF
--- a/instagram_private_api_extensions/live.py
+++ b/instagram_private_api_extensions/live.py
@@ -162,8 +162,6 @@ class Downloader(object):
         }, timeout=self.mpd_download_timeout)
         res.raise_for_status()
 
-        xml_text = res.text
-
         # IG used to send this header when the broadcast ended.
         # Leaving it in in case it returns.
         broadcast_ended = res.headers.get('X-FB-Video-Broadcast-Ended', '')
@@ -175,17 +173,13 @@ class Downloader(object):
         else:
             max_age = 0
 
-        # Use etag to detect if the same mpd is received repeatedly
-        etag = res.headers.get('etag')
-        if not etag:
-            # use contents hash as psuedo etag
-            m = hashlib.md5()
-            m.update(xml_text.encode('utf-8'))
-            etag = m.hexdigest()
-        if etag and etag != self.last_etag:
+        # Use ETag to detect if the same mpd is received repeatedly
+        # if missing, use contents hash as psuedo etag
+        etag = res.headers.get('ETag') or hashlib.md5(res.content).hexdigest()
+        if etag != self.last_etag:
             self.last_etag = etag
             self.duplicate_etag_count = 0
-        elif etag:
+        else:
             self.duplicate_etag_count += 1
 
         if broadcast_ended:
@@ -215,7 +209,7 @@ class Downloader(object):
                 self.is_aborted = True
 
         xml.etree.ElementTree.register_namespace('', MPD_NAMESPACE['mpd'])
-        mpd = xml.etree.ElementTree.fromstring(xml_text)
+        mpd = xml.etree.ElementTree.fromstring(res.text)
         minimum_update_period = mpd.attrib.get('minimumUpdatePeriod', '')
         mobj = re.match('PT(?P<secs>[0-9]+)S', minimum_update_period)
         if mobj:


### PR DESCRIPTION
## What does this PR do?
Handle the last MPD.

## Why was this PR needed?
Currently, the last mpd is download (with header `X-FB-Video-Broadcast-Ended=1`), then the downloader is marked as `aborted` without updating the etag from this last mpd.
Thus, the etag is unchanged and causes downloader to skip the processing of this mpd, even if this mpd contains some segments.

## Does this PR meet the acceptance criteria?

- [ ] Passes flake8 (refer to ``.travis.yml``)
- [ ] Docs are buildable
- [x] Branch has no merge conflicts with ``master``
- [ ] Is covered by a test